### PR TITLE
Add Flask chatroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# codexbox
+# Codex Box
+
+This repository contains a minimal Flask chatroom example.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the application with:
+
+```bash
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser to join the chat.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+from flask import Flask, render_template
+from flask_socketio import SocketIO, send
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret!'
+
+socketio = SocketIO(app)
+
+@app.route('/')
+def index():
+    return render_template('chat.html')
+
+@socketio.on('message')
+def handle_message(msg):
+    send(msg, broadcast=True)
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flask-socketio

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Chatroom</title>
+    <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
+  </head>
+  <body>
+    <ul id="messages"></ul>
+    <input id="message" autocomplete="off" /><button onclick="sendMessage()">Send</button>
+    <script>
+      var socket = io();
+
+      socket.on('message', function(msg) {
+        var li = document.createElement('li');
+        li.textContent = msg;
+        document.getElementById('messages').appendChild(li);
+      });
+
+      function sendMessage() {
+        var input = document.getElementById('message');
+        socket.send(input.value);
+        input.value = '';
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple chatroom with Flask and SocketIO
- add chat template and requirements list
- expand README with run instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f41c6b3048321bf59841c061d4906